### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -24,9 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.7
+        # 3.7 works, but is going to be EOL soon and flake8
+        # removed support for it in the latest version
           - 3.8
           - 3.9
+          - 3.10
+          - 3.11
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -28,7 +28,8 @@ jobs:
         # removed support for it in the latest version
           - 3.8
           - 3.9
-          - 3.10
+          # YAML, yay https://github.com/actions/runner/issues/1989
+          - '3.10'
           - 3.11
 
     steps:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest==6.2.1
-pytest-cov==2.10.1
-flake8==3.8.4
-wheel==0.36.2
-twine==3.4.1
+pytest==7.2.0
+pytest-cov==4.0.0
+flake8==6.0.0
+wheel==0.38.4
+twine==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     project_urls={
         "Changelog": "https://github.com/flix-tech/redis-tq/blob/master/CHANGELOG.md",  # noqa
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'redis',
     ],


### PR DESCRIPTION
Python 3.6 is deprecated, 3.7 is about to.

This change updates the setup.py and the github action accordingly, and while at it the libraries are updated too