### PR TITLE
Fix optimistic lock

### DIFF
--- a/redistq/task_queue.py
+++ b/redistq/task_queue.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import random
 from uuid import uuid4
 
 import redis
@@ -57,6 +58,12 @@ class TaskQueue:
         self._processing_queue = name + ':processing'
         self._tasks = name + ':tasks:'
         self._host = host
+        self.client_id = uuid4().hex
+        logger.info(f'Redis client id: {self.client_id}')
+
+        # automatically expires lock in 10 seconds
+        self.get_lock = name + ':get_lock'
+        self.lock_expiry = 10
 
         # called when ttl <= 0 for a task
         self.ttl_zero_callback = ttl_zero_callback
@@ -151,45 +158,51 @@ class TaskQueue:
         """
         # See comment in __init__ about moving jobs between queues in an
         # atomic fashion before you modify!
-        while True:
-            task_id = self.conn.lindex(self._queue, -1)
+        # acquire lock before fetching task to avoid race condition
+        while not self._acquire_lock(self.get_lock):
+            # sleep and try again randomly between 0-2 secs
+            time.sleep(random.uniform(0.0, 2.0))
 
-            # returns none when queue is empty
-            if task_id is None:
-                return None, None
+        task_id = self.conn.lindex(self._queue, -1)
 
-            task_id = task_id.decode()
-            logger.info(f'Got task with id {task_id}')
+        # returns none when queue is empty
+        if task_id is None:
+            self.conn.delete(self.get_lock)
+            return None, None
 
-            task = self.conn.get(self._tasks + task_id)
-            if task is None:
-                logger.info(f'{task_id} was marked complete by other worker')
-                continue
+        task_id = task_id.decode()
+        logger.info(f'Got task with id {task_id}')
 
-            task = self._deserialize(task)
-            now = time.time()
-
-            with self.conn.pipeline() as pipeline:
-                try:
-                    # optimistic locking, to avoid race condition and retry.
-                    # requires transaction, setting deadline and moving task
-                    # from one queue to another should be atomic. If not then
-                    # there is a possibility that task do not have any
-                    # deadline(None) but it is in the self._processing_queue
-                    # and leads to dangling task sitting in redis until
-                    # manually removed.
-                    pipeline.watch(self._processing_queue,
-                                   self._tasks + task_id)
-                    task['deadline'] = now + task['lease_timeout']
-                    pipeline.multi()    # starts transaction
-                    pipeline.set(self._tasks + task_id, self._serialize(task))
-                    pipeline.lrem(self._queue, -1, task_id)
-                    pipeline.lpush(self._processing_queue, task_id)
-                    pipeline.execute()  # ends transaction
-                    return task['task'], task_id
-                except redis.WatchError:
-                    logger.info(f'{task_id} is being processed by another '
-                                'worker, will fetch new task')
+        with self.conn.pipeline() as pipeline:
+            try:
+                # requires transaction, setting deadline and moving task
+                # from one queue to another should be atomic. If not then
+                # there is a possibility that task do not have any
+                # deadline(None) but it is in the self._processing_queue
+                # and leads to dangling task sitting in redis until
+                # manually removed.
+                # After getting the lock from above, it should not raise
+                # WatchError, this is just an extra precautions incase
+                # lock timesout
+                pipeline.watch(self._tasks + task_id)
+                task = pipeline.get(self._tasks + task_id)
+                # returns none when task is not found
+                if task is None:
+                    logger.info(f'{task_id} was completed by other worker')
+                    pipeline.delete(self.get_lock)
+                    return None, None
+                pipeline.multi()    # starts transaction
+                task = self._deserialize(task)
+                task['deadline'] = time.time() + task['lease_timeout']
+                pipeline.set(self._tasks + task_id, self._serialize(task))
+                pipeline.lrem(self._queue, -1, task_id)
+                pipeline.lpush(self._processing_queue, task_id)
+                pipeline.delete(self.get_lock)
+                pipeline.execute()  # ends transaction
+                return task['task'], task_id
+            except redis.WatchError:
+                logger.info(f'{task_id} is being processed by another '
+                            'worker, will fetch new task')
 
     def __iter__(self):
         """Iterate over tasks and mark them as complete.
@@ -382,6 +395,31 @@ class TaskQueue:
                     except redis.WatchError:
                         logger.info('Skipping lease check, already performed '
                                     'by another worker')
+
+    def _acquire_lock(self, lockname):
+        """ Acquire lock for a duration of lock timeout
+            and automatically releases when expires
+
+            If fails to get lock then check the expiration on the lock
+            and if it's not set, set it. This could happen when client crashes
+            between set and expire operation (occurs rarely)
+
+            parameters
+            ----------
+                lockname: str
+
+            returns
+            -------
+            client_id otherwise False
+                True: Successfully accquired lock
+                False: Failed to get lock
+        """
+        if self.conn.setnx(lockname, self.client_id):
+            self.conn.expire(lockname, self.lock_expiry)
+            return True
+        elif self.conn.ttl(lockname) == -1:
+            self.conn.expire(lockname, self.lock_expiry)
+        return False
 
     def _serialize(self, task):
         task = json.dumps(task, sort_keys=True)

--- a/redistq/task_queue.py
+++ b/redistq/task_queue.py
@@ -410,7 +410,7 @@ class TaskQueue:
 
             returns
             -------
-            client_id otherwise False
+            bool
                 True: Successfully accquired lock
                 False: Failed to get lock
         """

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -333,3 +333,25 @@ def test_lock_automatically_releases(taskqueue):
     taskqueue.client_id = 1234
     time.sleep(taskqueue.lock_expiry)
     assert taskqueue._acquire_lock(taskqueue.get_lock)
+
+
+@pytest.mark.redis
+def test_release_lock_it_owns(taskqueue):
+    # acquire lock
+    taskqueue._acquire_lock(taskqueue.get_lock)
+
+    # release its own lock
+    taskqueue._release_lock(taskqueue.get_lock)
+    assert taskqueue.conn.get(taskqueue.get_lock) is None
+
+
+@pytest.mark.redis
+def test_do_not_release_lock_owned_by_other(taskqueue):
+    # mimick lock obtained by other worker
+    client_id = taskqueue.client_id
+    taskqueue._acquire_lock(taskqueue.get_lock)
+
+    # current worker should not release the lock owned by other worker
+    taskqueue.client_id = 1234
+    taskqueue._release_lock(taskqueue.get_lock)
+    assert taskqueue.conn.get(taskqueue.get_lock).decode() == client_id

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -305,3 +305,31 @@ def test_lease_timout_is_not_float_or_int(taskqueue):
     # 1.0) without causing an error. so be it
     with pytest.raises(ValueError):
         taskqueue.add('bla', lease_timeout="foo")
+
+
+@pytest.mark.redis
+def test_acquire_lock_success(taskqueue):
+    # worker successfuly acquires lock
+    assert taskqueue._acquire_lock(taskqueue.get_lock)
+
+
+@pytest.mark.redis
+def test_acquire_lock_fail(taskqueue):
+    # mimick lock obtained by other worker
+    taskqueue._acquire_lock(taskqueue.get_lock)
+
+    # now current worker should not be able to get the lock
+    taskqueue.client_id = 1234
+    assert not taskqueue._acquire_lock(taskqueue.get_lock)
+
+
+@pytest.mark.redis
+def test_lock_automatically_releases(taskqueue):
+    # mimick lock obtained by other worker
+    taskqueue.lock_expiry = 2
+    taskqueue._acquire_lock(taskqueue.get_lock)
+
+    # now current worker should get lock after waiting for lock timeout
+    taskqueue.client_id = 1234
+    time.sleep(taskqueue.lock_expiry)
+    assert taskqueue._acquire_lock(taskqueue.get_lock)


### PR DESCRIPTION
Pipeline along with watch is not sufficient to provide unique task to workers, since its an optimistic lock and doesn't guarantee. That means its possible that more than one worker gets the same task.
To avoid above problem, a special lock and release functions are added to achieve mutex functionality. Lock is implemented using key value, key->lockname and value->workerID
Lock is also automatically released when it times out, in case the worker crashes or dead.

changes:
 - acquire_lock
 - release lock
 - get